### PR TITLE
Set up continuous deployment to PaaS

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: build

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1,0 +1,112 @@
+---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+resources:
+  - name: git-main
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/govuk-account-team-manual.git
+      branch: main
+
+  - name: govuk-slack
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/((slack_webhook_url))
+
+jobs:
+  - name: update-pipeline
+    plan:
+      - get: git-main
+        trigger: true
+      - set_pipeline: govuk-account-team-manual
+        file: git-main/concourse/pipeline.yml
+
+  - name: build-and-deploy
+    serial: true
+    plan:
+      - get: git-main
+        trigger: true
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.7.1-buster
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
+          inputs:
+            - name: git-main
+              path: src
+          outputs:
+            - name: site
+              path: src/build
+          run:
+            dir: src
+            path: sh
+            args:
+              - "-exc"
+              - |
+                apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y --no-install-recommends nodejs
+                bundle
+                bundle exec middleman build
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Build for the Account Team Manual has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+      - task: deploy
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli
+              tag: e1ffec0d1940706f157a8c1e0ab8131b7084fa1c
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
+          inputs:
+            - name: git-main
+              path: src
+            - name: site
+              path: src/build
+          params:
+            CF_API: https://api.london.cloud.service.gov.uk
+            CF_USERNAME: ((paas-username))
+            CF_PASSWORD: ((paas-password))
+          run:
+            dir: src
+            path: sh
+            args:
+              - "-exc"
+              - |
+                cf api "$CF_API"
+                cf auth
+                cf t -o govuk-accounts -s production
+                cf push
+        on_failure:
+          put: govuk-slack
+          params:
+            channel: '#govuk-accounts-tech'
+            username: 'Concourse (GOV.UK Accounts)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Deployment for the Account Team Manual has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: govuk-account-team-manual
+  memory: 64M
+  buildpacks:
+  - staticfile_buildpack


### PR DESCRIPTION
Site: https://team-manual.account.publishing.service.gov.uk/

Pipeline: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-account-team-manual

---

[Trello card](https://trello.com/c/JZJZsSqO/506-deploy-the-tech-docs-team-manual-to-the-paas)