### PR TITLE
Document the full `fly login` command

### DIFF
--- a/source/development-tasks/deploy-a-branch-to-staging/index.html.md.erb
+++ b/source/development-tasks/deploy-a-branch-to-staging/index.html.md.erb
@@ -19,7 +19,7 @@ If the branch you want to deploy is on GitHub, use the existing Concourse pipeli
 1. Sign in to Concourse:
 
     ```
-    fly -t cd-govuk-tools login
+    fly login -t cd-govuk-tools -c https://cd.gds-reliability.engineering -n govuk-tools
     ```
 
 2. Disable deployments to production:


### PR DESCRIPTION
`fly -t cd-govuk-tools login` will work if you've logged in to the govuk-tools team before, and chosen `cd-govuk-tools` as that target name.

But if you're signing in to concourse for the first time, or if you've called your target something else, you'll get a confusing `error: unknown target: cd-govuk-tools` error.

If we document the full form of the command, users following these docs will always get the right settings for the `cd-govuk-tools` target.

See https://concourse-ci.org/fly.html#fly-login for more details on the login command.