### PR TITLE
Add link to overall GOV.UK incident management process

### DIFF
--- a/source/incident/index.html.md.erb
+++ b/source/incident/index.html.md.erb
@@ -1,12 +1,14 @@
 ---
 title: Incident management
 weight: 50
-last_reviewed_on: 2020-12-10
+last_reviewed_on: 2021-01-12
 review_in: 6 months
 ---
 
 # Incident management
 
-- determine if there is an incident
-- investigate, resolve and close incidents
-- standardised responses / playbooks for common incidents & alerts
+The GOV.UK Account team follows the overall GOV.UK incident management process.
+
+See the [GOV.UK incident management documentation](https://docs.google.com/document/d/1ty12B5eBWB9YSfnD9xY1mr5rtTQxdNxRdmEGgibilN0/edit#heading=h.6xyivp2rx18o) for more information.
+
+See the [support documentation in the team manual](/support/#support) for more information on other support tasks.


### PR DESCRIPTION
Adds link to GOV.UK incident management process to the incident management page in the team manual in line with https://trello.com/c/LEEB3RcZ/558-link-team-manual-to-govuk-incident-management-process.