### PR TITLE
Augment new starter content

### DIFF
--- a/source/new-starter/access/index.html.md.erb
+++ b/source/new-starter/access/index.html.md.erb
@@ -1,10 +1,77 @@
 ---
-title: Access
+title: Get access to required apps
 weight: 23
 last_reviewed_on: 2020-12-10
 review_in: 6 months
 ---
 
-# Access
+# Get access to required apps and information
 
-List of all the things you should have access to and how to get that access
+When you join the GOV.UK Account team, you must get access to all the required apps and information you need.
+
+## Complete the GOV.UK new starter process
+
+If you are a new developer on GDS or the GOV.UK programme, you must complete the GOV.UK developer new starter process.
+
+See the [documentation on getting started on GOV.UK](https://docs.publishing.service.gov.uk/manual/get-started.html) for more information.
+
+At the end of this process, you should have access to the following:
+
+- the GOV.UK production environment
+- [GDS Concourse](https://cd.gds-reliability.engineering/)
+- the GOV.UK GitHub team
+
+If you are not are new to GDS or the GOV.UK programme, you should have already completed this process.
+
+## Get access to GOV.UK Account team internal tools
+
+Ask the delivery manager for access to the following GOV.UK Account team internal tools:
+
+- [Trello](https://trello.com/) boards
+- [Google drive](https://drive.google.com/drive/folders/1v31pO7qAHMIkQxqF3xZNPcjnEsITnzIU).
+- [Zendesk](https://docs.publishing.service.gov.uk/manual/zendesk.html)
+- [`govuk-accounts` Slack channel](https://app.slack.com/client/T8GT9416G/C012GEZBZM0)
+- [`govuk-accounts-tech` Slack channel](https://app.slack.com/client/T8GT9416G/C011Y5SAY3U)
+
+## Get access to GOV.UK PaaS and Notify
+
+Ask the GOV.UK Account tech lead or lead developer for access to the following:
+
+- [GOV.UK PaaS](https://www.cloud.service.gov.uk/) as a [space developer](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#space-developer)
+- the GOV.UK Account team space on [GOV.UK Notify](https://www.notifications.service.gov.uk/)
+
+## Get access to GOV.UK Account developer Google group
+
+Ask any GOV.UK Account developer to add you to the [GOV.UK Account developer Google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-accounts-developers).
+
+## Get access to Splunk
+
+To access Splunk, raise a IT request:
+
+1. Sign in to the [GDS IT & Estates Web Help Desk](https://gdshelpdesk.digital.cabinet-office.gov.uk/helpdesk/WebObjects/Helpdesk.woa).
+1. In __Request Type__, select __GDS IT Requests__ > __People & accounts__ > __Other Account Requests__.
+1. In __Request Detail__, enter "Please apply gds-027-govuk-accounts role to my google account."
+1. For __Account type__, select __LDAP__.
+1. In __For Google changes__, select __Account correction/change__.
+1. In __Is this request for you?__, select __Yes__.
+1. Select your __Location__ and __Room__, and select __Save__.
+
+When IT tell you the request is complete, check that you can access the [GOV.UK Account Splunk dashboard](https://gds.splunkcloud.com/en-US/app/gds-027-govuk-accounts/dashboards).
+
+## Check access to the GOV.UK Account Grafana dashboard
+
+Check that you have access to the [GOV.UK Account Grafana dashboard](https://grafana-paas.cloudapps.digital/d/_g_9aRoMk/gov-uk-accounts).
+
+If you cannot access this dashboard, speak to IT using Slack or [raise an IT request]([GDS IT & Estates Web Help Desk](https://gdshelpdesk.digital.cabinet-office.gov.uk/helpdesk/WebObjects/Helpdesk.woa).
+
+## Give GOV.UK Seal access to your Github name
+
+The Account team use [Seal Slack bot](https://github.com/alphagov/seal) to give helpful prompts on Slack. One example is the morning reminder for pull requests that require review.
+
+Seal needs to know which GitHub user is in which team. This configuration is described in the [Seal alphagov.yml file](https://github.com/alphagov/seal/blob/master/config/alphagov.yml#L128-L162).
+
+If your username is not already on the list, add your username to the list and raise a pull request, asking other team members to review.
+
+Once the pull request has been merged, the change is automatically deployed to the heroku app.
+
+See this [example Seal pull request](https://github.com/alphagov/seal/pull/205/files) for reference.

--- a/source/new-starter/background/index.html.md.erb
+++ b/source/new-starter/background/index.html.md.erb
@@ -5,4 +5,14 @@ last_reviewed_on: 2020-12-10
 review_in: 6 months
 ---
 
-# Background
+# Background to GOV.UK Account
+
+Read the following for background information on GOV.UK Account:
+
+- [How we designed the GOV.UK Account trial](https://insidegovuk.blog.gov.uk/2020/11/26/how-we-designed-the-gov-uk-accounts-trial/)
+- [Introducing GOV.UK Accounts](https://gds.blog.gov.uk/2020/09/22/introducing-gov-uk-accounts/)
+- [Five things we’ve learned from researching the GOV.UK account](https://insidegovuk.blog.gov.uk/2020/12/09/five-things-weve-learned-from-researching-the-gov-uk-account/)
+- [The technical architecture behind a GOV.UK account](https://insidegovuk.blog.gov.uk/2021/01/07/the-technical-architecture-behind-a-gov-uk-account/)
+- [Using accounts to personalise the user experience on GOV.UK](https://insidegovuk.blog.gov.uk/2020/10/07/using-accounts-to-personalise-the-user-experience-on-gov-uk/)
+- [New trial to offer streamlined use of GOV.UK](https://www.gov.uk/government/news/new-trial-to-offer-streamlined-use-of-govuk)
+- [Julia Lopez's speech at techUK’s ‘Building the Smarter State’ Conference](https://www.gov.uk/government/speeches/julia-lopez-speech-at-techuks-building-the-smarter-state-conference)

--- a/source/new-starter/how-it-works/index.html.md.erb
+++ b/source/new-starter/how-it-works/index.html.md.erb
@@ -1,8 +1,65 @@
 ---
-title: How GOV.UK Accounts works
+title: How GOV.UK Account works
 weight: 22
 last_reviewed_on: 2020-12-10
 review_in: 6 months
 ---
 
-# How GOV.UK Accounts works
+# How GOV.UK Account works
+
+The core GOV.UK account architecture includes:
+
+- an authentication service
+- an attribute store
+
+In the future, the architecture should also include:
+
+- a broker
+- a preferences and consent management service
+- a trust framework
+- a fraud protection and monitoring service
+
+## Current architecture features
+
+### Authentication
+
+The authentication service handles:
+
+- user registration
+- two-factor authentication (2FA)
+- user sign-ins
+- password resets and confirmation emails
+
+### Attribute store
+
+The attribute store is a centralised location that holds some common data about a user that every GOV.UK service might need.
+
+## Future architecture features
+
+### Broker
+
+The broker is a service that all other services and the user interacts with and through.
+
+The broker also blinds services from each other and makes sure services only access the personal data that users consent to sharing.
+
+### Preferences and consent management service
+
+The preferences and consent management service:
+
+- allows the user to control consent over how and when their data is shared
+- gives the user a security trail of when and where their data was used
+
+### Trust framework
+
+The trust framework ensures and guarantees the trust of the various interacting services.
+
+### Fraud protection and monitoring service
+
+The fraud protection and monitoring service proactively identifies malicious or fraudulent behaviour and alerts developers and security professionals.
+
+## Further information
+
+For more information on the GOV.UK Account architecture, see the:
+
+- [technical architecture behind a GOV.UK account blog](https://insidegovuk.blog.gov.uk/2021/01/07/the-technical-architecture-behind-a-gov-uk-account/)
+- [GOV.UK Account technical architecture repo documentation](https://github.com/alphagov/govuk-account-architecture/blob/master/docs/GOV.UK-Accounts.md#1-accounts-phase-1).

--- a/source/new-starter/index.html.md.erb
+++ b/source/new-starter/index.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # New starter guide
 
-- background to GOV.UK Accounts
-- how GOV.UK Accounts works
+- background to GOV.UK Account
+- how GOV.UK Account works
 - what you should have access to
 - how to set up your local environment

--- a/source/new-starter/install-tools/index.html.md.erb
+++ b/source/new-starter/install-tools/index.html.md.erb
@@ -1,0 +1,64 @@
+---
+title: Install developer tools
+weight: 23
+last_reviewed_on: 2020-12-10
+review_in: 6 months
+---
+
+# Install developer tools
+
+The GOV.UK Account team uses the following developer tools:
+
+- `gds-cli`, the Government Digital Service Command Line Interface (CLI)](https://github.com/alphagov/gds-cli) to connect to the VPN and update secrets
+- fly, a CLI to interact with Concourse
+- the CloudFoundry CLI to interact with our servers on the GOV.UK PaaS
+
+When you join the GOV.UK Account team, you must install these tools.
+
+## Install the gds-cli
+
+The `gds-cli` is a CLI to [connect to the VPN](https://docs.publishing.service.gov.uk/manual/get-started.html#4-connecting-to-the-gds-vpn) and [update secrets](/support/rotate-secrets/#rotate-a-secret).
+  
+To install `gds-cli`, see the [GOV.UK Developer documentation on installing GDS tooling](https://docs.publishing.service.gov.uk/manual/get-started.html#3-install-gds-tooling) for more information.
+
+## Install the fly CLI
+
+[fly](https://concourse-ci.org/fly.html) is a CLI to interact with our Concourse pipelines.
+
+Before you install fly, you must have access to Concourse.
+
+In install fly:
+
+1. Sign in to the GDS VPN using the command line or the Cisco AnyConnect Secure Mobility Client.
+1. Go to the GDS [Concourse instance](https://cd.gds-reliability.engineering/teams/govuk-tools).
+1. Sign in with your GDS GitHub account.
+
+At the bottom of the page there is a section labled __cli__, next to which are three links:
+
+- Download OS X CLI
+- Download Windows CLI
+- Download Linux CLI
+
+Choose the right option for your operating system, and install the downloaded CLI.
+
+Once you have finished, you can confirm fly is correctly installed by running `fly --version`. You should get a response with a version number.
+
+This version should match the version seen at the bottom of the [GDS Concourse instance](https://cd.gds-reliability.engineering/teams/govuk-tools).
+
+## Install the CloudFoundry CLI
+
+The CloudFoundry CLI lets you to interact with our servers on the GOV.UK PaaS.
+
+Currently, there are two main versions of the CloudFoundary CLI, v6 and v7.
+
+You should use v7. The team and documentation in this manual assume that you are using v7.
+
+To download and install v7, see the [CloudFoundry documentation on how to install v7 of the CLI](https://github.com/cloudfoundry/cli/wiki/V7-CLI-Installation-Guide#downloading-the-latest-v7-cf-cli).
+
+Once you have installed the CloudFoundry CLI, check you have the right version by running `cf --version`.
+
+You should get a response with a version number that starts with `cf version 7.`. For example:
+
+```
+cf version 7.2.0+be4a5ce2b.2020-12-10
+```

--- a/source/support/resolve/index.html.md.erb
+++ b/source/support/resolve/index.html.md.erb
@@ -1,15 +1,15 @@
 ---
-title: Resolve issues with GOV.UK Accounts
+title: Resolve issues with GOV.UK Account
 weight: 32
 last_reviewed_on: 2020-12-10
 review_in: 6 months
 ---
 
-# Resolve issues with GOV.UK Accounts
+# Resolve issues with GOV.UK Account
 
 If you are the on-call support developer, you may receive an alert if
-there is a problem with GOV.UK Accounts.  The Senior Management Team
-(SMT) may also contact you if you need to scale up GOV.UK Accounts at
+there is a problem with GOV.UK Account.  The Senior Management Team
+(SMT) may also contact you if you need to scale up GOV.UK Account at
 short notice.
 
 This content covers the reasons you may get called and what to do in
@@ -57,17 +57,17 @@ A key-value store for user attributes. This prototype currently only stores user
 
 See the [GOV.UK Attribute Service Prototype GitHub repository][repo-attribute-service] for more information.
 
-#### GOV.UK Accounts Architecture
+#### GOV.UK Account Architecture
 
 Contains information on how the system architecture works.
 
-See the [GOV.UK Accounts Architecture GitHub repository][repo-architecture] for more information.
+See the [GOV.UK Account Architecture GitHub repository][repo-architecture] for more information.
 
-#### GOV.UK Accounts Tech Docs
+#### GOV.UK Account Tech Docs
 
 Contains our technical documentation.
 
-See the [GOV.UK Accounts Tech Docs GitHub repository][repo-docs] for more information.
+See the [GOV.UK Account Tech Docs GitHub repository][repo-docs] for more information.
 
 #### GOV.UK Docker
 
@@ -101,7 +101,7 @@ The apps communicate, so a problem in one could cascade to the other.
 
 ## Solving the problem
 
-GOV.UK Accounts is still part of GOV.UK, so make sure to follow the
+GOV.UK Account is still part of GOV.UK, so make sure to follow the
 [GOV.UK developer documentation incident guidance][incident], in addition to diagnosing and
 fixing any accounts-specific issue.
 

--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -118,7 +118,7 @@ In the interim, we should thank the users who sent feedback. If it feels appropr
 1. Respond to the user using the [__GOV.UK Account: Additional feedback requested__ macro](#gov-uk-account-additional-feedback-requested).
 1. Submit the ticket as pending.
 
-### If the ticket is not for GOV.UK Accounts to solve
+### If the ticket is not for GOV.UK Account to solve
 
 Upon further investigation, a ticket may not be for our team to solve. For example, if it is to do with other things such as a visa application.
 
@@ -129,7 +129,7 @@ In this case, you must send the ticket back to the 2nd line user support escalat
 1. Add an internal note explaining why.
 1. Submit the ticket as __new__ using the dropdown at the bottom.
 
-### If the ticket is not to do with GOV.UK Accounts or government
+### If the ticket is not to do with GOV.UK Account or government
 
 Sometimes we get tickets that are not about anything to do with GOV.UK or the government.
 


### PR DESCRIPTION
Augment new starter content:

- Background page - add links to blogs explaining the background of GOV.UK Account
- How GOV.UK Account works - summarise different parts of the architecture and links to more detailed information
- Get access to required apps and information - add in information
- Created section telling new starters what tools they need to install

Also changed "GOV.UK Accounts" to "GOV.UK Account" in two sections

As per https://trello.com/c/uB19t27Z/559-review-and-augment-new-starter-content-in-team-manual