### PR TITLE
Expand triage content

### DIFF
--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -7,9 +7,9 @@ review_in: 6 months
 
 # Solve Zendesk tickets
 
-## How tickets are triaged to the GOV.UK Account team 2nd line
+## How Zendesk tickets are assigned to the GOV.UK Account team
 
-All tickets go through 1st line user support first. 1st line only send us tickets that are about:
+All Zendesk tickets go through GOV.UK first line user support. The GOV.UK first line user support escalation team sends us tickets by assigning those tickets to __2nd line Accounts__ in Zendesk. We are assigned tickets that are about the following:
 
 - feedback on the account
 - a technical issue a user is having

--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -9,7 +9,9 @@ review_in: 6 months
 
 ## How Zendesk tickets are assigned to the GOV.UK Account team
 
-All Zendesk tickets go through GOV.UK first line user support. The GOV.UK first line user support escalation team sends us tickets by assigning those tickets to __2nd line Accounts__ in Zendesk. We are assigned tickets that are about the following:
+When a user submits a public feedback form, this creates a Zendesk ticket in the GOV.UK second line escalation support queue.
+
+The GOV.UK second line escalation support team sends GOV.UK Account-specific tickets to the GOV.UK Account team by assigning those tickets to __2nd line Accounts__ in Zendesk. GOV.UK Account-specific tickets can be about:
 
 - feedback on the account
 - a technical issue a user is having


### PR DESCRIPTION
The team manual has a section on resolving Zendesk tickets. The beginning of this section states how tickets are assigned to the GOV.UK Account 2nd line support. This content change gives more detail on this process.

https://trello.com/c/3qwxtfmR/539-document-how-support-tickets-are-triaged-to-our-team