### PR TITLE
Add content on how to set up a view in Zendesk

### DIFF
--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -29,7 +29,7 @@ Before you can respond to and solve Zendesk tickets, you must set up the correct
 1. Enter 'GOV.UK accounts feedback' in the __Title__ field.
 1. Enter 'View of open GOV.UK accounts tickets' in the __Description__ field.
 1. Under __Who has access__, select __Only you__.
-1. Under __Conditions__, set the following 2 conditions:
+1. Under __Conditions > Tickets must meet all of these conditions to appear in the view__, add the following 2 conditions:
     - Add a first condition by selecting the following options:
       - __Group__
       - __Is__
@@ -39,6 +39,10 @@ Before you can respond to and solve Zendesk tickets, you must set up the correct
       - __Is not__
       - __Solved__
 1. Select __Save__ at the bottom of the page.
+
+After selecting __Save__, you are back on the __Admin > Views__ page. To access your new view from this page, change the option on the right hand side of the page from __All shared views__ to __Personal views__. You should see your newly created view.
+
+You can also access your new view by selecting __Views__ in the left hand navigation and looking under __Your views__. You may need to refresh your views using the refresh icon at the top of the __Views__ menu.
 
 ## Respond to and solve tickets
 

--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -19,6 +19,28 @@ The GOV.UK second line escalation support team sends GOV.UK Account-specific tic
 
 The owners of GOV.UK Account second line support in Zendesk are the team delivery manager and product manager. They are responsible for the tickets, macros and prepared responses.
 
+## Set up Zendesk view
+
+Before you can respond to and solve Zendesk tickets, you must set up the correct view in Zendesk.
+
+1. Sign into [Zendesk](https://govuk.zendesk.com/). If you do not have access to Zendesk, speak to the Accounts team delivery manager to get access.
+1. Go to __Views__ and select __More >>__ at the bottom left of the page.
+1. Select __Add view__ at the top right of the page.
+1. Enter 'GOV.UK accounts feedback' in the __Title__ field.
+1. Enter 'View of open GOV.UK accounts tickets' in the __Description__ field.
+1. Under __Who has access__, select __Only you__.
+1. Under __Conditions__, set the following 2 conditions:
+    - Add a first condition by selecting the following options:
+      - __Group__
+      - __Is__
+      - __2nd Line--GOV.UK Accounts__
+    - Add a second condition by selecting the following options:
+      - __Status__
+      - __Is not__
+      - __Solved__
+
+1. Select __Save__ at the bottom of the page.
+
 ## Respond to and solve tickets
 
 There’s a [GOV.UK Account team rota](https://docs.google.com/spreadsheets/d/1cfoRyupvHzIqrcdes_JwQh_qbuwCiNqIuMt_iTDz8Tc/edit#gid=1167069729) for dealing with support tickets.

--- a/source/support/zendesk/index.html.md.erb
+++ b/source/support/zendesk/index.html.md.erb
@@ -38,7 +38,6 @@ Before you can respond to and solve Zendesk tickets, you must set up the correct
       - __Status__
       - __Is not__
       - __Solved__
-
 1. Select __Save__ at the bottom of the page.
 
 ## Respond to and solve tickets


### PR DESCRIPTION
#What

Add content explaining how to set up a view in Zendesk to the team manual. The content will come from https://docs.google.com/document/d/1JrXnbSM6U88wdOP35YVHev_5sfllJSnSpmYkYUeT2j4/edit.

## Why

So everyone knows how to have the right view in Zendesk for when they are on the Zendesk rota.

## Who

Jon

## Definition of done

The content is in the team manual.

Trello card: https://trello.com/c/4dGjiKFP/761-add-how-to-set-up-a-view-in-zendesk-to-the-team-manual
